### PR TITLE
Be careful in major-modes in which `mode-line-process' is a simple st…

### DIFF
--- a/native-complete.el
+++ b/native-complete.el
@@ -78,14 +78,25 @@ setting `TERM' to a value other then dumb."
                return style)
       'tab))
 
+(defun native-complete--redirection-active-p ()
+  "Indicate whether redirection is currently active."
+  (string-match-p "Redirection"
+                  (cond
+                   ((stringp mode-line-process)
+                    mode-line-process)
+                   ((consp mode-line-process)
+                    (car mode-line-process))
+                   (t
+                    ""))))
+
 (defun native-complete--usable-p ()
   "Return non-nil if native-complete can be used at point."
   (and (memq major-mode native-complete-major-modes)
-       (not (string-match-p "Redirection" (or (car mode-line-process) "")))))
+       (not (native-complete--redirection-active-p))))
 
 (defun native-complete-abort (&rest _)
   "Abort completion and cleanup redirect if needed."
-  (when (string-match-p "Redirection" (or (car mode-line-process) ""))
+  (when (native-complete--redirection-active-p)
     (comint-redirect-cleanup)))
 
 (advice-add 'comint-send-input :before 'native-complete-abort)


### PR DESCRIPTION
Hello Troy,

I get the following error when sending input to the GDB process using `comint-send-input` in `gud-mode`:

    apply: Wrong type argument: listp, #(":run [ready]" 6 11 (face font-lock-variable-name-face))

In `gud-mode` the variable `mode-line-process` is a plain string.

This change fixed it for me.

Thank you very much.

  Emilio

