### PR TITLE
Fix compilation error due to cl-lib not available at run time

### DIFF
--- a/native-complete.el
+++ b/native-complete.el
@@ -29,6 +29,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'subr-x)
 (require 'shell)
 


### PR DESCRIPTION
`cl` and `cl-lib` is not longer automatically loaded into emacs 27, so this package results in a compilation error during installation without this fix.