### PR TITLE
In README: Explain why there are two packages.

### DIFF
--- a/README.org
+++ b/README.org
@@ -20,10 +20,16 @@ Currently this has been tested in
 
 ** Emacs setup
 This project contains two completion packages, ~native-complete~ for basic
-completion and ~company-native-complete~ for ~company-mode~. ~native-complete~
+completion and ~company-native-complete~ for ~company-mode~.  
+Choose one.  Why are there two? 
+[[https://github.com/company-mode/company-mode/issues/68#issuecomment-36208504][Here]] 
+and [[https://github.com/auto-complete/auto-complete/issues/503][here]]
+are two comparisons of the two main modular completion frameworks for Emacs: auto-complete and CompAny (Complete Any).
+The standard and the leading shiny new alternative.   For users of the built-in auto-complete package, 
+~native-complete~
 provides ~native-complete-at-point~ which is a "completion at point function"
 (capf) and can be enabled by adding it to ~completion-at-point-functions~ in a
-shell buffer. ~company-native-complete~ provides a function of the same name which
+shell buffer. For users of the add-on company package ~company-native-complete~ provides a function of the same name which
 is an asynchronous backend for the company completion framework. It is enabled
 by adding it to ~company-backends~.
 

--- a/README.org
+++ b/README.org
@@ -18,14 +18,23 @@ Currently this has been tested in
 - csh
 - sqlite
 
-** Emacs setup
+* Setup steps:
+
+** 1. Emacs setup
+
 This project contains two completion packages, ~native-complete~ for basic
 completion and ~company-native-complete~ for ~company-mode~.  
 Choose one.  Why are there two? 
 [[https://github.com/company-mode/company-mode/issues/68#issuecomment-36208504][Here]] 
 and [[https://github.com/auto-complete/auto-complete/issues/503][here]]
 are two comparisons of the two main modular completion frameworks for Emacs: auto-complete and CompAny (Complete Any).
-The standard and the leading shiny new alternative.   For users of the built-in auto-complete package, 
+The standard and the leading shiny new alternative.   
+
+It can be installed from Melpa with M-x `package-install' RET [company-]native-complete.
+It can also be installed manually in the traditional way, just be mindful of the dependencies.
+
+
+For users of the built-in auto-complete package, 
 ~native-complete~
 provides ~native-complete-at-point~ which is a "completion at point function"
 (capf) and can be enabled by adding it to ~completion-at-point-functions~ in a
@@ -33,9 +42,10 @@ shell buffer. For users of the add-on company package ~company-native-complete~ 
 is an asynchronous backend for the company completion framework. It is enabled
 by adding it to ~company-backends~.
 
-** shell setup
+** 2. shell setup
 *** bash
-Run ~native-complete-setup-bash~ in Emacs /before/ you load your first shell.
+Run ~native-complete-setup-bash~ in Emacs /before/ you load your first shell.  
+(Add this to your emacs configuration file.)
 #+BEGIN_SRC elisp
   (with-eval-after-load 'shell
     (native-complete-setup-bash))
@@ -54,7 +64,7 @@ Make sure editing is enabled.
 #+END_SRC
 
 ** Advanced setup
-For most users this package should work out the box. However if you are using an
+For most users this package should work out the box after the above steps. However if you are using an
 unusual shell or are invoking subshells that are a different type then your main
 shell, you may need add some additional configuration.
 


### PR DESCRIPTION
I had no clue _what_ company _was_ as I was reading the README! So I thought adding a bit to the documentation to help others in my shoes would be helpful.  So here's a perhaps crude first attempt. Perhaps I presume one can only use one at a time incorrectly.    I have no opinion on which is better.  Maybe these deep links are too much?   These links, one to an issue within each product, provide info which seems useful.  

Would adding some basic installation tips would be helpful, like

> It can be installed from Melpa with M-x `package-install' RET [company-]native-complete.
It can also be installed manually in the traditional way, just be mindful of the dependencies.

